### PR TITLE
Adding support for Sherlock's ForceOverflow themes

### DIFF
--- a/HoloEverywhereLib/res/values/styles.xml
+++ b/HoloEverywhereLib/res/values/styles.xml
@@ -61,7 +61,63 @@
 		<item name="android:spinnerItemStyle">@style/SpinnerItemLight</item>
 		<item name="android:spinnerDropDownItemStyle">@style/DropDownItemLight</item>
 	</style>
-		
+
+	<style name="Theme.HoloEverywhereDark.Sherlock.ForceOverflow" parent="Theme.Sherlock.ForceOverflow">
+        <item name="android:windowBackground">@drawable/background_holo_dark</item>
+        <item name="android:listViewStyle">@style/ListViewStyle</item>
+        <item name="android:buttonStyle">@style/ButtonHoloDark</item>
+        <item name="android:imageButtonStyle">@style/ButtonHoloDark</item>
+        <item name="android:editTextStyle">@style/EditTextHoloDark</item>
+        <item name="android:alertDialogStyle">@style/AlertDialogHoloDark</item>
+        <item name="android:radioButtonStyle">@style/RadioHoloDark</item>
+        <item name="android:checkboxStyle">@style/CheckBoxHoloDark</item>
+        <item name="android:seekBarStyle">@style/SeekBarHolo</item>
+        <item name="android:progressBarStyle">@style/ProgressBarHolo</item>
+        <item name="android:progressBarStyleSmall">@style/ProgressBarHolo.Small</item>
+        <item name="android:progressBarStyleLarge">@style/ProgressBarHolo.Large</item>
+        <item name="android:progressBarStyleHorizontal">@style/ProgressBarHolo.Horizontal</item>
+        <item name="android:spinnerStyle">@style/SpinnerDark</item>
+        <item name="android:spinnerItemStyle">@style/SpinnerItemDark</item>
+        <item name="android:spinnerDropDownItemStyle">@style/DropDownItemDark</item>
+    </style>
+
+	<style name="Theme.HoloEverywhereLight.Sherlock.ForceOverflow" parent="Theme.Sherlock.Light.ForceOverflow">
+        <item name="android:windowBackground">@drawable/background_holo_light</item>
+        <item name="android:listViewStyle">@style/ListViewStyle</item>
+        <item name="android:buttonStyle">@style/ButtonHoloLight</item>
+        <item name="android:imageButtonStyle">@style/ButtonHoloLight</item>
+        <item name="android:editTextStyle">@style/EditTextHoloLight</item>
+        <item name="android:alertDialogStyle">@style/AlertDialogHoloLight</item>
+        <item name="android:radioButtonStyle">@style/RadioHoloLight</item>
+        <item name="android:checkboxStyle">@style/CheckBoxHoloLight</item>
+        <item name="android:seekBarStyle">@style/SeekBarHolo</item>
+        <item name="android:progressBarStyle">@style/ProgressBarHolo</item>
+        <item name="android:progressBarStyleSmall">@style/ProgressBarHolo.Small</item>
+        <item name="android:progressBarStyleLarge">@style/ProgressBarHolo.Large</item>
+        <item name="android:progressBarStyleHorizontal">@style/ProgressBarHolo.Horizontal</item>
+        <item name="android:spinnerStyle">@style/SpinnerLight</item>
+        <item name="android:spinnerItemStyle">@style/SpinnerItemLight</item>
+        <item name="android:spinnerDropDownItemStyle">@style/DropDownItemLight</item>
+    </style>
+
+	<style name="Theme.HoloEverywhereLight.DarkActionBar.Sherlock.ForceOverflow" parent="Theme.Sherlock.Light.DarkActionBar.ForceOverflow">
+        <item name="android:windowBackground">@drawable/background_holo_light</item>
+        <item name="android:listViewStyle">@style/ListViewStyle</item>
+        <item name="android:buttonStyle">@style/ButtonHoloLight</item>
+        <item name="android:imageButtonStyle">@style/ButtonHoloLight</item>
+        <item name="android:editTextStyle">@style/EditTextHoloLight</item>
+        <item name="android:alertDialogStyle">@style/AlertDialogHoloLight</item>
+        <item name="android:radioButtonStyle">@style/RadioHoloLight</item>
+        <item name="android:checkboxStyle">@style/CheckBoxHoloLight</item>
+        <item name="android:seekBarStyle">@style/SeekBarHolo</item>
+        <item name="android:progressBarStyle">@style/ProgressBarHolo</item>
+        <item name="android:progressBarStyleSmall">@style/ProgressBarHolo.Small</item>
+        <item name="android:progressBarStyleLarge">@style/ProgressBarHolo.Large</item>
+        <item name="android:progressBarStyleHorizontal">@style/ProgressBarHolo.Horizontal</item>
+        <item name="android:spinnerStyle">@style/SpinnerLight</item>
+        <item name="android:spinnerItemStyle">@style/SpinnerItemLight</item>
+        <item name="android:spinnerDropDownItemStyle">@style/DropDownItemLight</item>
+    </style>
 
 	<style name="Theme.HoloEverywhereDark" parent="android:Theme.NoTitleBar">
 		<item name="android:windowBackground">@drawable/background_holo_dark</item>


### PR DESCRIPTION
I needed to use Theme.Sherlock.ForceOverflow with HoloEverywhere, so I decided to inherit and add the following themes:

Theme.HoloEverywhereDark.Sherlock.ForceOverflow
Theme.HoloEverywhereLight.Sherlock.ForceOverflow
Theme.HoloEverywhereLight.DarkActionBar.Sherlock.ForceOverflow
