### PR TITLE
Don't use "focused" background for all inactive EditTexts.

### DIFF
--- a/HoloEverywhereLib/res/drawable/edit_text_holo.xml
+++ b/HoloEverywhereLib/res/drawable/edit_text_holo.xml
@@ -19,14 +19,12 @@
     <item  android:state_window_focused="false" android:state_enabled="true"  android:drawable="@drawable/textfield_multiline_default_holo_dark" />
     <item  android:state_window_focused="false" android:state_enabled="false" android:drawable="@drawable/textfield_multiline_disabled_holo_dark" />
     <item  android:state_enabled="true" android:state_focused="true" android:drawable="@drawable/textfield_multiline_activated_holo_dark" />
-    <item  android:state_enabled="true" android:drawable="@drawable/textfield_multiline_focused_holo_dark" />
     <item  android:state_enabled="true" android:drawable="@drawable/textfield_multiline_default_holo_dark" />
     <item  android:state_focused="true" android:drawable="@drawable/textfield_multiline_disabled_focused_holo_dark" />
 
     <item android:state_window_focused="false" android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_dark" />
     <item android:state_window_focused="false" android:state_enabled="false" android:drawable="@drawable/textfield_disabled_holo_dark" />
     <item android:state_enabled="true" android:state_focused="true" android:drawable="@drawable/textfield_activated_holo_dark" />
-    <item android:state_enabled="true"  android:drawable="@drawable/textfield_focused_holo_dark" />
     <item android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_dark" />
     <item android:state_focused="true" android:drawable="@drawable/textfield_disabled_focused_holo_dark" />
     <item android:drawable="@drawable/textfield_disabled_holo_dark" />

--- a/HoloEverywhereLib/res/drawable/edit_text_holo_dark.xml
+++ b/HoloEverywhereLib/res/drawable/edit_text_holo_dark.xml
@@ -19,7 +19,6 @@
     <item android:state_window_focused="false" android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_dark" />
     <item android:state_window_focused="false" android:state_enabled="false" android:drawable="@drawable/textfield_disabled_holo_dark" />
     <item android:state_enabled="true" android:state_focused="true" android:drawable="@drawable/textfield_activated_holo_dark" />
-    <item android:state_enabled="true"  android:drawable="@drawable/textfield_focused_holo_dark" />
     <item android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_dark" />
     <item android:state_focused="true" android:drawable="@drawable/textfield_disabled_focused_holo_dark" />
     <item android:drawable="@drawable/textfield_disabled_holo_dark" />

--- a/HoloEverywhereLib/res/drawable/edit_text_holo_light.xml
+++ b/HoloEverywhereLib/res/drawable/edit_text_holo_light.xml
@@ -19,7 +19,6 @@
     <item android:state_window_focused="false" android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_light" />
     <item android:state_window_focused="false" android:state_enabled="false" android:drawable="@drawable/textfield_disabled_holo_light" />
     <item android:state_enabled="true" android:state_focused="true" android:drawable="@drawable/textfield_activated_holo_light" />
-    <item android:state_enabled="true"  android:drawable="@drawable/textfield_focused_holo_light" />
     <item android:state_enabled="true" android:drawable="@drawable/textfield_default_holo_light" />
     <item android:state_focused="true" android:drawable="@drawable/textfield_disabled_focused_holo_light" />
     <item android:drawable="@drawable/textfield_disabled_holo_light" />


### PR DESCRIPTION
The official Android source only uses the focused background for android:state_activated="true" (although this state is probably completely ignored because of the iten typo).

"state_activated" is only supported in pre-honeycomb, so I'm assuming that's why that qualifier was removed for the focused background. However, in this case it completely overrides the state for textfield_default_holo_light, and all non-focused EditText's will have the focused background.

I think it's better to simply never use the focused background - the activated background is good enough.
