### PR TITLE
Maven: switch to Android 4.1.1.4 to fix compile errors.

### DIFF
--- a/HoloDemo/pom.xml
+++ b/HoloDemo/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.wazabe.holoeverywhere</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/HoloEverywhereLib/pom.xml
+++ b/HoloEverywhereLib/pom.xml
@@ -10,7 +10,7 @@
 	<parent>
 		<groupId>com.wazabe.holoeverywhere</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.0</version>
+		<version>1.0.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 	<groupId>com.wazabe.holoeverywhere</groupId>
 	<artifactId>parent</artifactId>
 	<packaging>pom</packaging>
-	<version>1.0.0</version>
+	<version>1.0.1-SNAPSHOT</version>
 
 	<name>HoloEverywhere (Parent)</name>
 	<description>Android library bringing Holo Theme to Android 1.6 and above.</description>
@@ -52,8 +52,8 @@
 		<apk.prefix>holoeverywhere</apk.prefix>
 
 		<java.version>1.6</java.version>
-		<android.version>4.0.1.2</android.version>
-		<android.platform>14</android.platform>
+		<android.version>4.1.1.4</android.version>
+		<android.platform>16</android.platform>
 		<android-support.version>r7</android-support.version>
 
 		<android-maven.version>3.1.1</android-maven.version>
@@ -72,7 +72,7 @@
 			<dependency>
 				<groupId>com.actionbarsherlock</groupId>
 				<artifactId>library</artifactId>
-				<version>4.0.2</version>
+				<version>4.1.0</version>
 				<type>apklib</type>
 			</dependency>
 		</dependencies>


### PR DESCRIPTION
Also updated actionbarsherlock depencency and bumped POM version. I believe it's better to use a SNAPSHOT version for everything except actual releases.
