### PR TITLE
Fix checkbox for dark-theme which looks like a radiobutton

### DIFF
--- a/HoloEverywhereLib/res/values/styles.xml
+++ b/HoloEverywhereLib/res/values/styles.xml
@@ -77,7 +77,7 @@
         <item name="android:textColor">#000000</item>
     </style>
     <style name="Holo.CheckBox" parent="@android:style/Widget.CompoundButton.CheckBox">
-        <item name="android:button">?android:attr/checkMark</item>
+        <item name="android:button">@drawable/btn_checkbox_holo_dark</item>
         <item name="android:textColor">#ffffff</item>
     </style>
     <style name="Holo.CheckBox.Light">


### PR DESCRIPTION
I tested this in Froyo, but this problem should appear on all API's <14.
