### PR TITLE
Removes extra textAppearanceListItemSmall

### DIFF
--- a/library/res/values-v14/styles.xml
+++ b/library/res/values-v14/styles.xml
@@ -58,7 +58,6 @@
         <item name="switchStyleOld">@style/Holo.Switch.Old</item>
         <item name="textAppearanceLargePopupMenu">@style/Holo.TextAppearance.PopupMenu.Large</item>
         <item name="textAppearanceListItem">?android:textAppearanceLarge</item>
-        <item name="textAppearanceListItemSmall">?android:textAppearanceMedium</item>
         <item name="textAppearanceSmallPopupMenu">@style/Holo.TextAppearance.PopupMenu.Small</item>
         <item name="textColorAlertDialogListItem">@color/primary_text_holo_dark</item>
         <!--End of block BaseDark-->

--- a/library/res/values/styles.xml
+++ b/library/res/values/styles.xml
@@ -659,7 +659,6 @@
         <item name="switchStyleOld">@style/Holo.Switch.Old</item>
         <item name="textAppearanceLargePopupMenu">@style/Holo.TextAppearance.PopupMenu.Large</item>
         <item name="textAppearanceListItem">?android:textAppearanceLarge</item>
-        <item name="textAppearanceListItemSmall">?android:textAppearanceMedium</item>
         <item name="textAppearanceSmallPopupMenu">@style/Holo.TextAppearance.PopupMenu.Small</item>
         <item name="textColorAlertDialogListItem">@color/primary_text_holo_dark</item>
         <!--End of block BaseDark-->


### PR DESCRIPTION
It appears that `Holo.Theme` defined `textAppearanceListItemSmall` twice.
