### PR TITLE
Remove duplicate resource entry

### DIFF
--- a/library/resources/base.json
+++ b/library/resources/base.json
@@ -61,7 +61,6 @@
             "switchStyleOld": "@style/Holo.Switch.Old", 
             "textAppearanceLargePopupMenu": "@style/Holo.TextAppearance.PopupMenu.Large", 
             "textAppearanceListItem": "?android:textAppearanceLarge", 
-            "textAppearanceListItemSmall": "?android:textAppearanceMedium", 
             "textAppearanceSmallPopupMenu": "@style/Holo.TextAppearance.PopupMenu.Small", 
             "textColorAlertDialogListItem": "@color/primary_text_holo_dark"
         }, 


### PR DESCRIPTION
The duplication of `textAppearanceListItemSmall` in `Base` and `BaseDark` is causing an error in Maven.
