### PR TITLE
Changing IAddon to allow clients to use HoloEverywhere without needing to switch to JDK7

### DIFF
--- a/library/src/org/holoeverywhere/addon/IAddon.java
+++ b/library/src/org/holoeverywhere/addon/IAddon.java
@@ -1,17 +1,17 @@
 
 package org.holoeverywhere.addon;
 
-import java.util.Map;
-import java.util.WeakHashMap;
-
 import org.holoeverywhere.app.Activity;
 import org.holoeverywhere.app.Fragment;
+
+import java.util.Map;
+import java.util.WeakHashMap;
 
 public abstract class IAddon<A extends IAddonActivity, F extends IAddonFragment> {
     private final Map<Object, Object> statesMap = new WeakHashMap<Object, Object>();
 
     public A activity(Activity activity) {
-        A addon = get(activity);
+        A addon = (A) get(activity);
         if (addon == null) {
             addon = createAddon(activity);
             put(activity, addon);
@@ -36,7 +36,7 @@ public abstract class IAddon<A extends IAddonActivity, F extends IAddonFragment>
     }
 
     public F fragment(Fragment fragment) {
-        F addon = get(fragment);
+        F addon = (F) get(fragment);
         if (addon == null) {
             addon = createAddon(fragment);
             put(fragment, addon);
@@ -45,8 +45,8 @@ public abstract class IAddon<A extends IAddonActivity, F extends IAddonFragment>
     }
 
     @SuppressWarnings("unchecked")
-    public <T> T get(Object key) {
-        return (T) statesMap.get(key);
+    public Object get(Object key) {
+        return statesMap.get(key);
     }
 
     public void put(Object key, Object value) {


### PR DESCRIPTION
This is a small change that has zero impact inside HoloEverywhere and I strongly suspect it is extremely unlikely to have any adverse impact on any HE clients. And the worse case impact is that client would need to cast the output of IAddon#get to the expect type.

The upside is that HoloEverywhere would no longer enforce a dependency on JDK7 on clients.
