### PR TITLE
Add new method setDismissOnButtonClick(boolean) to AlertDialog and AlertDialog.Builder

### DIFF
--- a/library/src/org/holoeverywhere/app/AlertDialog.java
+++ b/library/src/org/holoeverywhere/app/AlertDialog.java
@@ -113,6 +113,11 @@ public class AlertDialog extends Dialog implements DialogInterface,
             return this;
         }
 
+        public Builder setDismissOnButtonClick(boolean dismiss) {
+            P.mDismissOnButtonClick = dismiss;
+            return this;
+        }
+
         public Builder setIcon(Drawable icon) {
             P.mIcon = icon;
             return this;
@@ -446,6 +451,10 @@ public class AlertDialog extends Dialog implements DialogInterface,
 
     public void setCustomTitle(View customTitleView) {
         mAlert.setCustomTitle(customTitleView);
+    }
+
+    public void setDismissOnButtonClick(boolean dismiss) {
+        mAlert.setDismissOnButtonClick(dismiss);
     }
 
     public void setIcon(Drawable icon) {

--- a/library/src/org/holoeverywhere/internal/AlertController.java
+++ b/library/src/org/holoeverywhere/internal/AlertController.java
@@ -55,6 +55,7 @@ public class AlertController {
         public final Context mContext;
         public Cursor mCursor;
         public View mCustomTitleView;
+        public boolean mDismissOnButtonClick = true;
         public boolean mForceInverseBackground;
         public Drawable mIcon;
         public int mIconId = 0;
@@ -107,6 +108,7 @@ public class AlertController {
                     dialog.setIcon(mIconId);
                 }
             }
+            dialog.setDismissOnButtonClick(mDismissOnButtonClick);
             if (mMessage != null) {
                 dialog.setMessage(mMessage);
             }
@@ -322,8 +324,11 @@ public class AlertController {
             if (m != null) {
                 m.sendToTarget();
             }
-            mHandler.obtainMessage(ButtonHandler.MSG_DISMISS_DIALOG,
-                    mDialogInterface).sendToTarget();
+
+            if (mDismissOnButtonClick) {
+                mHandler.obtainMessage(ButtonHandler.MSG_DISMISS_DIALOG,
+                        mDialogInterface).sendToTarget();
+            }
         }
     };
     private Button mButtonNegative;
@@ -339,6 +344,7 @@ public class AlertController {
     private final Context mContext;
     private View mCustomTitleView;
     private final DialogInterface mDialogInterface;
+    private boolean mDismissOnButtonClick = true;
     private boolean mForceInverseBackground;
     private Handler mHandler;
     private Drawable mIcon;
@@ -561,6 +567,10 @@ public class AlertController {
 
     public void setCustomTitle(View customTitleView) {
         mCustomTitleView = customTitleView;
+    }
+
+    public void setDismissOnButtonClick(boolean dismiss) {
+        mDismissOnButtonClick = dismiss;
     }
 
     public void setIcon(Drawable icon) {


### PR DESCRIPTION
An annoyance of AlertDialogs is the inability to prevent the dismissal of the dialog on button click without using convoluted means to set the button click listener directly. This simply prevents the generated OnClickListener for the button from sending the dismiss message when a flag is set. The default is to dismiss the dialog on button click to maintain current functionality.
