### PR TITLE
Bug fix in DialogFragment.findInstance

### DIFF
--- a/library/src/org/holoeverywhere/app/DialogFragment.java
+++ b/library/src/org/holoeverywhere/app/DialogFragment.java
@@ -41,17 +41,24 @@ public class DialogFragment extends Fragment implements
     @SuppressWarnings("unchecked")
     public static final <T extends DialogFragment> T findInstance(Activity activity,
             Class<T> clazz, boolean makeIfNeed) {
+
         if (activity == null || clazz == null) {
             throw new IllegalArgumentException("Activity of DialogFragment class is null");
         }
-        FragmentManager ft = activity.getSupportFragmentManager();
+
+        return findInstance(activity.getSupportFragmentManager(), clazz, makeIfNeed);
+    }
+
+    @SuppressWarnings("unchecked")
+    public static final <T extends DialogFragment> T findInstance(FragmentManager fm,
+            Class<T> clazz, boolean makeIfNeed) {
+
         T fragment;
         final String tag = makeTag(clazz);
         try {
-            fragment = (T) ft.findFragmentByTag(tag);
+            fragment = (T) fm.findFragmentByTag(tag);
             if (fragment == null && makeIfNeed) {
                 fragment = Fragment.instantiate(clazz);
-                ft.putFragment(fragment.getArguments(), tag, fragment);
             }
         } catch (Exception e) {
             throw new RuntimeException("Error of finding DialogFragment instance", e);


### PR DESCRIPTION
Line:
ft.putFragment(fragment.getArguments(), tag, fragment);

putFragment is intended to put the fragment state into a bundle for restoration at a later time. This cannot be called before a fragment has been added to the fragment manager or an exception is thrown. (case: makeIfNeed=true) From what I can tell, this is completely unnecessary and probably not intend.

Additional: added another findInstance that takes a fragment manager rather than an activity to allow it to be used with child fragment managers.
