### PR TITLE
Fix the light background drawable

### DIFF
--- a/library/res/drawable/background_holo_light.xml
+++ b/library/res/drawable/background_holo_light.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-	android:shape="rectangle" >
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
 	<gradient
-		android:endColor="#fbfbfb"
-		android:gradientRadius="270"
-		android:startColor="#e8e8e8"
-		android:type="radial" />
+		android:startColor="#ffe8e8e8"
+		android:endColor="#ffffffff"
+		android:angle="270" />
 </shape>


### PR DESCRIPTION
The Holo light background in AOSP is not a radial gradient. This commit
replaces the drawable with a copy of the AOSP drawable.
