### PR TITLE
Fix for parseFontStyle

### DIFF
--- a/library/src/org/holoeverywhere/widget/ListView.java
+++ b/library/src/org/holoeverywhere/widget/ListView.java
@@ -246,7 +246,7 @@ public class ListView extends android.widget.ListView implements OnWindowFocusCh
         TypedArray a = context.obtainStyledAttributes(attrs, new int[] {
                 android.R.attr.choiceMode,              // 16843051
                 android.R.attr.fastScrollEnabled,       // 16843302
-                android.R.attr.setOverscrollHeader,     // 16843458
+                android.R.attr.overScrollHeader,        // 16843458
                 android.R.attr.overScrollFooter,        // 16843459
                 android.R.attr.fastScrollAlwaysVisible, // 16843573
         }, defStyle, R.style.Holo_ListView);
@@ -256,7 +256,7 @@ public class ListView extends android.widget.ListView implements OnWindowFocusCh
         if (!a.hasValue(3) && VERSION.SDK_INT >= VERSION_CODES.GINGERBREAD) { // overScrollFooter
             super.setOverscrollFooter(null);
         }
-        if (!a.hasValue(2) && VERSION.SDK_INT >= VERSION_CODES.GINGERBREAD) { // setOverscrollHeader
+        if (!a.hasValue(2) && VERSION.SDK_INT >= VERSION_CODES.GINGERBREAD) { // overScrollHeader
             super.setOverscrollHeader(null);
         }
         a.recycle();

--- a/library/src/org/holoeverywhere/widget/ListView.java
+++ b/library/src/org/holoeverywhere/widget/ListView.java
@@ -241,20 +241,22 @@ public class ListView extends android.widget.ListView implements OnWindowFocusCh
         }
         super.setFastScrollEnabled(false);
         super.setChoiceMode(CHOICE_MODE_NONE);
+        // http://stackoverflow.com/questions/8675709/getting-style-attributes-dynamically/9087694#9087694
+        // There are special requirements on how it is structured -- the resource identifiers need to be in sorted order, as this is part of the optimization to quickly retrieving them
         TypedArray a = context.obtainStyledAttributes(attrs, new int[] {
-                android.R.attr.fastScrollEnabled,
-                android.R.attr.fastScrollAlwaysVisible,
-                android.R.attr.choiceMode,
-                android.R.attr.overScrollFooter,
-                android.R.attr.overScrollHeader
+                android.R.attr.choiceMode,              // 16843051
+                android.R.attr.fastScrollEnabled,       // 16843302
+                android.R.attr.setOverscrollHeader,     // 16843458
+                android.R.attr.overScrollFooter,        // 16843459
+                android.R.attr.fastScrollAlwaysVisible, // 16843573
         }, defStyle, R.style.Holo_ListView);
-        setFastScrollEnabled(a.getBoolean(0, false));
-        setFastScrollAlwaysVisible(a.getBoolean(1, false));
-        setChoiceMode(a.getInt(2, CHOICE_MODE_NONE));
-        if (!a.hasValue(3) && VERSION.SDK_INT >= VERSION_CODES.GINGERBREAD) {
+        setFastScrollEnabled(a.getBoolean(1, false)); // fastScrollEnabled
+        setFastScrollAlwaysVisible(a.getBoolean(4, false)); // fastScrollAlwaysVisible
+        setChoiceMode(a.getInt(0, CHOICE_MODE_NONE)); // choiceMode
+        if (!a.hasValue(3) && VERSION.SDK_INT >= VERSION_CODES.GINGERBREAD) { // overScrollFooter
             super.setOverscrollFooter(null);
         }
-        if (!a.hasValue(4) && VERSION.SDK_INT >= VERSION_CODES.GINGERBREAD) {
+        if (!a.hasValue(2) && VERSION.SDK_INT >= VERSION_CODES.GINGERBREAD) { // setOverscrollHeader
             super.setOverscrollHeader(null);
         }
         a.recycle();

--- a/library/src/org/holoeverywhere/widget/TextView.java
+++ b/library/src/org/holoeverywhere/widget/TextView.java
@@ -56,23 +56,26 @@ public class TextView extends android.widget.TextView implements FontStyleProvid
      */
     @SuppressLint("InlinedApi")
     public static int parseFontStyle(Context context, AttributeSet attrs, int defStyleAttr) {
+        // http://stackoverflow.com/questions/8675709/getting-style-attributes-dynamically/9087694#9087694
+        // There are special requirements on how it is structured -- the resource identifiers need to be in sorted order, as this is part of the optimization to quickly retrieving them
         TypedArray a = context.obtainStyledAttributes(attrs, new int[] {
-                android.R.attr.fontFamily,
-                android.R.attr.typeface,
-                android.R.attr.textStyle
+            android.R.attr.typeface,   // 16842902
+            android.R.attr.textStyle,  // 16842903
+            android.R.attr.fontFamily, // 16843692
         }, defStyleAttr, 0);
+
         final TypedValue value = new TypedValue();
-        a.getValue(0, value);
+        a.getValue(2, value);
         if (value.string != null) {
             a.recycle();
             return parse(value.string.toString());
         } else {
             int i = TEXT_STYLE_NORMAL;
-            a.getValue(1, value);
+            a.getValue(0, value);
             if (value.string != null) {
                 i |= parse(value.string.toString());
             }
-            i |= a.getInt(2, TEXT_STYLE_NORMAL);
+            i |= a.getInt(1, TEXT_STYLE_NORMAL);
             a.recycle();
             return i;
         }


### PR DESCRIPTION
Resource identifiers in obtainStyledAttributes must be sorted, or on some devices (at least on Huawei U9508) obtainStyledAttributes returns empty result.
