### PR TITLE
Gradle build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 target/
 bin/
 gen/
+
+# Gradle
+.gradle
+build

--- a/addons/preferences/AndroidManifest.xml
+++ b/addons/preferences/AndroidManifest.xml
@@ -1,3 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1006000" android:versionName="1.6.0" package="org.holoeverywhere.preference">
 	<uses-sdk android:minSdkVersion="7" android:targetSdkVersion="16"/>
+	<application/>
 </manifest>

--- a/addons/preferences/build.gradle
+++ b/addons/preferences/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'android-library'
+
+dependencies {
+  compile project(':library')
+}
+
+android {
+  compileSdkVersion 17
+  buildToolsVersion '17'
+
+  defaultConfig {
+    targetSdkVersion 17
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile 'AndroidManifest.xml'
+      java.srcDirs = ['src']
+      res.srcDirs = ['res']
+    }
+  }
+}

--- a/addons/slider/AndroidManifest.xml
+++ b/addons/slider/AndroidManifest.xml
@@ -1,11 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1006000" android:versionName="1.6.0" package="org.holoeverywhere.slider">
 	<uses-sdk android:minSdkVersion="7" android:targetSdkVersion="17"/>
-	<application android:allowBackup="true" android:name="org.holoeverywhere.app.Application" android:theme="@style/Holo.Theme.Light.DarkActionBar">
-		<activity android:name=".Test">
-			<intent-filter>
-				<action android:name="android.intent.action.MAIN"/>
-				<category android:name="android.intent.category.LAUNCHER"/>
-			</intent-filter>
-		</activity>
-	</application>
+	<application/>
 </manifest>

--- a/addons/slider/build.gradle
+++ b/addons/slider/build.gradle
@@ -1,0 +1,22 @@
+apply plugin: 'android-library'
+
+dependencies {
+  compile project(':library')
+}
+
+android {
+  compileSdkVersion 17
+  buildToolsVersion '17'
+
+  defaultConfig {
+    targetSdkVersion 17
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile 'AndroidManifest.xml'
+      java.srcDirs = ['src']
+      res.srcDirs = ['res']
+    }
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,23 @@
+buildscript {
+  repositories {
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath 'com.android.tools.build:gradle:0.4.2'
+  }
+}
+
+allprojects {
+  group = 'org.holoeverywhere'
+  version = '1.6.2-SNAPSHOT'
+
+  repositories {
+    mavenCentral()
+    maven {
+      url "https://github.com/dahlgren/abs-aar/raw/master"
+    }
+  }
+}
+
+apply plugin: 'android-reporting'

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,0 +1,24 @@
+apply plugin: 'android'
+
+dependencies {
+  compile project(':library')
+  compile project(':addons:preferences')
+  compile project(':addons:slider')
+}
+
+android {
+  compileSdkVersion 17
+  buildToolsVersion '17'
+
+  defaultConfig {
+    targetSdkVersion 17
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile 'AndroidManifest.xml'
+      java.srcDirs = ['src']
+      res.srcDirs = ['res']
+    }
+  }
+}

--- a/library/AndroidManifest.xml
+++ b/library/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1006000" android:versionName="1.6.0" package="org.holoeverywhere">
 	<uses-sdk android:minSdkVersion="7" android:targetSdkVersion="16"/>
+	<application/>
 </manifest>

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'android-library'
+
+dependencies {
+  compile 'com.android.support:support-v4:13.0.0'
+  compile 'com.actionbarsherlock:actionbarsherlock:4.3.2-SNAPSHOT'
+}
+
+android {
+  compileSdkVersion 17
+  buildToolsVersion '17'
+
+  defaultConfig {
+    targetSdkVersion 17
+  }
+
+  sourceSets {
+    main {
+      manifest.srcFile 'AndroidManifest.xml'
+      java.srcDirs = ['src']
+      res.srcDirs = ['res']
+    }
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,4 @@
+include 'library'
+include 'addons:preferences'
+include 'addons:slider'
+include 'demo'


### PR DESCRIPTION
I've setup an aar repo with a snapshot of ActionBarSherlock 4.3.2, I'd recommend you'd either fork it or create your own for HoloEverywhere to depend on for now until the aar is available from a maven repository. Using a github repo with the maven repo and accessing it through the raw endpoint of github works fine. Note that ABS should be built with the "Android Support Repository" instead of the Support Library available from most maven repositories to avoid any errors with duplicate classes in the Support Library.

The empty application tag inside each addon and library manifest is due to a bug which is supposed to be fixed in the 0.5.0 gradle android plugin. If no application tag is present when a library depends on a library a null pointer exception is thrown. The test activity is also removed from the slider addon manifest so that it doesn't get merged into a built application's manifest depending on the slider addon.

Let me know if any changes are required.
