### PR TITLE
Контекст в DatePickerDialog

### DIFF
--- a/library/src/org/holoeverywhere/app/DatePickerDialog.java
+++ b/library/src/org/holoeverywhere/app/DatePickerDialog.java
@@ -42,7 +42,7 @@ public class DatePickerDialog extends AlertDialog implements OnClickListener,
         setButton(DialogInterface.BUTTON_NEGATIVE,
                 getContext().getText(android.R.string.cancel), this);
         setIcon(0);
-        LayoutInflater inflater = LayoutInflater.from(context);
+        LayoutInflater inflater = LayoutInflater.from(getContext());
         View view = inflater.inflate(R.layout.date_picker_dialog, null);
         setView(view);
         mDatePicker = (DatePicker) view.findViewById(R.id.datePicker);


### PR DESCRIPTION
Заметил, что в DatePickerDialog для inflater'a используется контекст, переданный в конструктор, а не тот, что отправился в конструктор диалога. Поэтому не подхватывался стиль для DatePicker'a
