### PR TITLE
HoloEverywhere ProgressBar does not use native Android progress bar drawable ids

### DIFF
--- a/library/res/values/ids.xml
+++ b/library/res/values/ids.xml
@@ -1,6 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?><resources>
-	<item name="progress" type="id"></item>
-	<item name="secondaryProgress" type="id"></item>
 	<item name="edit" type="id"></item>
 	<item name="leftSpacer" type="id"></item>
 	<item name="rightSpacer" type="id"></item>

--- a/library/src/org/holoeverywhere/widget/ProgressBar.java
+++ b/library/src/org/holoeverywhere/widget/ProgressBar.java
@@ -274,7 +274,7 @@ public class ProgressBar extends android.widget.ProgressBar {
         } else {
             invalidate();
         }
-        if (callBackToApp && id == R.id.progress) {
+        if (callBackToApp && id == android.R.id.progress) {
             onProgressRefresh(scale, fromUser);
         }
     }
@@ -629,7 +629,7 @@ public class ProgressBar extends android.widget.ProgressBar {
             if (mProgress > max) {
                 mProgress = max;
             }
-            refreshProgress(R.id.progress, mProgress, false);
+            refreshProgress(android.R.id.progress, mProgress, false);
         }
     }
 
@@ -650,7 +650,7 @@ public class ProgressBar extends android.widget.ProgressBar {
         }
         if (progress != mProgress) {
             mProgress = progress;
-            refreshProgress(R.id.progress, mProgress, fromUser);
+            refreshProgress(android.R.id.progress, mProgress, fromUser);
         }
     }
 
@@ -679,8 +679,8 @@ public class ProgressBar extends android.widget.ProgressBar {
         if (needUpdate) {
             updateDrawableBounds(getWidth(), getHeight());
             updateDrawableState();
-            doRefreshProgress(R.id.progress, mProgress, false, false);
-            doRefreshProgress(R.id.secondaryProgress, mSecondaryProgress,
+            doRefreshProgress(android.R.id.progress, mProgress, false, false);
+            doRefreshProgress(android.R.id.secondaryProgress, mSecondaryProgress,
                     false, false);
         }
     }
@@ -698,7 +698,7 @@ public class ProgressBar extends android.widget.ProgressBar {
         }
         if (secondaryProgress != mSecondaryProgress) {
             mSecondaryProgress = secondaryProgress;
-            refreshProgress(R.id.secondaryProgress, mSecondaryProgress, false);
+            refreshProgress(android.R.id.secondaryProgress, mSecondaryProgress, false);
         }
     }
 
@@ -765,7 +765,7 @@ public class ProgressBar extends android.widget.ProgressBar {
             for (int i = 0; i < N; i++) {
                 int id = background.getId(i);
                 outDrawables[i] = tileify(background.getDrawable(i),
-                        id == R.id.progress || id == R.id.secondaryProgress);
+                        id == android.R.id.progress || id == android.R.id.secondaryProgress);
             }
             LayerDrawable newBg = new LayerDrawable(outDrawables);
             for (int i = 0; i < N; i++) {


### PR DESCRIPTION
The native Android ProgressBar has a setProgressDrawable method (and equivalent xml attribute) that lets us specify the drawables used for the progress bar. It expects a layer-list that has drawables with particular ids (android.R.id.progress and android.R.id.secondaryProgress). To set the progress of a particular type (primary vs. secondary progress), it finds the appropriate drawable and then changes its level.

The HoloEverywhere library defines its own R.id.progress and R.id.secondaryProgress ids, and the HoloEverywhere ProgressBar class refers to these. This breaks compatibility with any drawables that use the original Android ProgressBar ids since the HoloEverywhere class does not look for them. Even the progress bar drawables included inside the HoloEverywhere library use android.R.id.progress (e.g. progress_horizontal_holo_dark.xml).

In the ProgressBar.doRefreshProgress method, if it can't find the drawable specified by the id, it falls back to the containing drawable (i.e. LayerDrawable containing all progress drawables), and then calls setLevel on that instead. Calling setLevel on a LayoutDrawable changes the level of all of the children. This is why if we only change the primary progress of a HoloEverywhere ProgressBar, it still appears to work.

The problem occurs when you try to set the secondary progress independently of the primary progress. With a HoloEverywhere ProgressBar, try the following:

```
progressBar.setProgress(50);
progressBar.setSecondaryProgress(75);
```

The expected behavior is that the primary progress drawable is at 50%, and the secondary progress drawable (usually drawn under the primary drawable) is at 75%.
The actual behavior with the HoloEverywhere ProgressBar is that both drawables are at 75%.

My suggested change is to just use the native android ids and remove the custom ones. Doing so makes the above case work correctly.
