### PR TITLE
holoeverywhere: transfer attributes set on EditTextPreference to EditTex...

### DIFF
--- a/addons/preferences/src/org/holoeverywhere/preference/EditTextPreference.java
+++ b/addons/preferences/src/org/holoeverywhere/preference/EditTextPreference.java
@@ -46,7 +46,7 @@ public class EditTextPreference extends DialogPreference {
 
     public EditTextPreference(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        mEditText = new EditText(getDialogContext(true));
+        mEditText = new EditText(getDialogContext(true), attrs);
         mEditText.setId(R.id.edit);
         mEditText.setEnabled(true);
     }


### PR DESCRIPTION
...t
- this allows stuff like inputType and numOfLines to be transferred correctly to the EditText
