### PR TITLE
Update Gradle plugin version to 0.6.+. (the new minimum version for Stud...

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
   }
 
   dependencies {
-    classpath 'com.android.tools.build:gradle:0.5.+'
+    classpath 'com.android.tools.build:gradle:0.6.+'
   }
 }
 


### PR DESCRIPTION
To be able to import HoloEverywhere into Android Studio, Android Gradle plugin version needs to be 0.6.+.
