### PR TITLE
Fix #675

### DIFF
--- a/library/src/android/support/v7/app/ActionBarActivityDelegateICS.java
+++ b/library/src/android/support/v7/app/ActionBarActivityDelegateICS.java
@@ -180,7 +180,7 @@ class ActionBarActivityDelegateICS extends ActionBarActivityDelegate {
 
         if (frameworkMode != null) {
             wrappedMode = new ActionModeWrapper(context,
-                    mActivity.startActionMode(wrappedCallback));
+                    frameworkMode);
             wrappedCallback.setLastStartedActionMode(wrappedMode);
         }
 


### PR DESCRIPTION
Eliminates duplicate call to startActionMode on the ActionBarActivity. This method is called immediately above the if block, and the resulting ActionMode is saved into the frameworkMode variable.
