### PR TITLE
support for non-scp authenticated deploy

### DIFF
--- a/android_default.gradle
+++ b/android_default.gradle
@@ -128,13 +128,12 @@ afterEvaluate { project ->
                 configuration = configurations.deployerJars
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-                def String repoUrl = project.properties.get('holoeverywhere.repo', 'file:///invalid_path')
-                if (repoUrl.startsWith('scpexe://')) {
-                    repository(url: repoUrl) {
+                repository(url: project.properties.get('holoeverywhere.repo', 'file:///invalid_path')) {
+                    if (project.properties.containsKey('holoeverywhere.repo.username') && project.properties.containsKey('holoeverywhere.repo.key')) {
                         authentication(userName: project.properties.get('holoeverywhere.repo.username'), privateKey: project.properties.get('holoeverywhere.repo.key'))
+                    } else if (project.properties.containsKey('holoeverywhere.repo.username') && project.properties.containsKey('holoeverywhere.repo.password')) {
+                        authentication(userName: project.properties.get('holoeverywhere.repo.username'), password: project.properties.get('holoeverywhere.repo.password'))
                     }
-                } else {
-                    repository(url: repoUrl)
                 }
 
                 pom.project {


### PR DESCRIPTION
Adds support for authenticated deploy via http, ftp, and other protocols support by maven deploy.

supported properties:
holoeverywhere.repo => repo url
holoeverywhere.repo.username => repo username (optional, unauthenticated deploy if unset)

one of the following is required when username is set
holoeverywhere.repo.password => repo password
or 
holoeverywhere.repo.key => repo private key for scp deploy
