### PR TITLE
Update transient_notification.xml

### DIFF
--- a/library/res/layout/transient_notification.xml
+++ b/library/res/layout/transient_notification.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="?toastFrameBackground"
+    android:background="@drawable/toast_frame"
     android:orientation="vertical">
 
     <TextView


### PR DESCRIPTION
This solve the exception:

Caused by: android.content.res.Resources$NotFoundException: Resource is not a Drawable (color or path): TypedValue{t=0x2/d=0x7f0100ab a=-1}

which appears in my app after upgrading to the latest commit of HoloEveryWhere.
