### PR TITLE
Fix crash in PreferenceScreen.onRestoreInstanceState()

### DIFF
--- a/addons/preferences/src/org/holoeverywhere/preference/PreferenceScreen.java
+++ b/addons/preferences/src/org/holoeverywhere/preference/PreferenceScreen.java
@@ -121,6 +121,10 @@ public class PreferenceScreen extends PreferenceGroup implements
 
     @Override
     protected void onRestoreInstanceState(Parcelable state) {
+        if (state == null || !state.getClass().equals(SavedState.class)) {
+            super.onRestoreInstanceState(state);
+            return;
+        }
         SavedState myState = (SavedState) state;
         super.onRestoreInstanceState(myState.getSuperState());
         if (myState.isShowing) {


### PR DESCRIPTION
There is PreferenceActivity with SwitchScreenPreference. When you try to rotate screen, an application crashes with exception:

``` javascript
Caused by: java.lang.ClassCastException: android.view.AbsSavedState$1 cannot be cast to org.holoeverywhere.preference.PreferenceScreen$SavedState
            at org.holoeverywhere.preference.PreferenceScreen.onRestoreInstanceState(PreferenceScreen.java:124)
            at org.holoeverywhere.preference.SwitchScreenPreference.onRestoreInstanceState(SwitchScreenPreference.java:123)
            at org.holoeverywhere.preference.Preference.dispatchRestoreInstanceState(Preference.java:148)
            at org.holoeverywhere.preference.PreferenceGroup.dispatchRestoreInstanceState(PreferenceGroup.java:87)
            at org.holoeverywhere.preference.PreferenceGroup.dispatchRestoreInstanceState(PreferenceGroup.java:90)
            at org.holoeverywhere.preference.PreferenceGroup.dispatchRestoreInstanceState(PreferenceGroup.java:90)
            at org.holoeverywhere.preference.Preference.restoreHierarchyState(Preference.java:935)
            at org.holoeverywhere.preference.PreferenceActivity.onRestoreInstanceState(PreferenceActivity.java:794)
            at android.app.Activity.performRestoreInstanceState(Activity.java:916)
...
```
