### PR TITLE
Added Codecov.io coverage reporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: java
+after_success: codecov
 jdk: openjdk7
 
 branches:
@@ -11,6 +12,7 @@ notifications:
     - prototypegamez@gmail.com
 
 before_install:
+  - sudo pip install codecov
   - export BASEDIR=`pwd`
   - export MAVEN_VERSION="3.1.1"
   - export ANDROID_BUILD_TOOLS="19.0.3"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![HoloEverywhere](https://github.com/Prototik/HoloEverywhere/raw/gh-pages/github-res/logo.png "HoloEverywhere")  
+![HoloEverywhere](https://github.com/Prototik/HoloEverywhere/raw/gh-pages/github-res/logo.png "HoloEverywhere")   [![codecov.io](https://codecov.io/github/Prototik/HoloEverywhere/coverage.svg?branch=master)](https://codecov.io/github/Prototik/HoloEverywhere?branch=master)
 [![Build Status](https://travis-ci.org/Prototik/HoloEverywhere.png?branch=master)](https://travis-ci.org/Prototik/HoloEverywhere)  
 Latest stable version: [2.1.0 Darkest Sunrise](https://github.com/Prototik/HoloEverywhere/releases/tag/v2.1.0)  
 Demo: [Stable][APKDemoStable] | [Latest][APKDemoLatest]  

--- a/pom.xml
+++ b/pom.xml
@@ -196,6 +196,25 @@
 						</proguard>
 					</configuration>
 				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.5.8.201207111220</version>
+					<executions>
+						<execution>
+							<goals>
+								<goal>prepare-agent</goal>
+							</goals>
+						</execution>
+						<execution>
+							<id>report</id>
+							<phase>test</phase>
+							<goals>
+								<goal>report</goal>
+							</goals>
+						</execution>
+					</executions>
+				</plugin>
 			</plugins>
 		</pluginManagement>
 	</build>


### PR DESCRIPTION
Hey Friends! I'm from [Codecov.io](https://codecov.io/) and I wanted to personally add our free coverage reporting tools to HoloEverywhere.

When travis-ci passes you can see the live reports here: [codecov.io/github/Prototik/HoloEverywhere](https://codecov.io/github/Prototik/HoloEverywhere?ref=e463f84e254b3d9f949e5e6362a5329d5c53ea7d)

[![codecov.io](https://codecov.io/github/Prototik/HoloEverywhere/coverage.svg?branch=master)](https://codecov.io/github/Prototik/HoloEverywhere?branch=master)

Make sure to [signup](https://codecov.io/login/github) to enable these free [features](https://codecov.io/#features)

I'm excited to hear your feedback!
Thank you for your time.
